### PR TITLE
Fixes for MacOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,11 +115,13 @@ else()
 	set(CMAKE_CXX_FLAGS_DEBUG "")
 	set(CMAKE_C_FLAGS_DEBUG "")
 
-	set(GODOT_LINKER_FLAGS "-static-libgcc -static-libstdc++ -Wl,-flto,--gc-sections,-R,'$$ORIGIN'")
+	if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+		set(GODOT_LINKER_FLAGS "-static-libgcc -static-libstdc++ -Wl,-flto,--gc-sections,-R,'$$ORIGIN'")
+		set(CMAKE_AR "gcc-ar")
+		set(CMAKE_NM "gcc-nm")
+		set(CMAKE_RANLIB "gcc-ranlib")
+	endif()
 
-  set(CMAKE_AR, "gcc-ar")
-  set(CMAKE_NM, "gcc-nm")
-	set(CMAKE_RANLIB "gcc-ranlib")
 	set(GODOT_COMPILE_FLAGS "-fPIC -flto -fvisibility=hidden -fvisibility-inlines-hidden -ffunction-sections -fdata-sections -fexceptions -frtti -pthread")
 
 	if(NOT CMAKE_BUILD_TYPE MATCHES Debug)

--- a/addons/godot-openmpt/openmpt.gdextension
+++ b/addons/godot-openmpt/openmpt.gdextension
@@ -4,7 +4,8 @@ entry_symbol = "godot_openmpt_init"
 compatibility_minimum = "4.2"
 
 [libraries]
-
+macos.debug = "bin/libgdmpt-darwin.debug.64.dylib"
+macos.release = "bin/libgdmpt-darwin.release.64.dylib"
 windows.debug.x86_64 = "bin/libgdmpt-windows.debug.64.dll"
 windows.release.x86_64 = "bin/libgdmpt-windows.release.64.dll"
 linux.debug.x86_64 = "bin/libgdmpt-linux.debug.64.so"


### PR DESCRIPTION
- Some Linux flags are not appropriate for all 'non-Windows' platforms. Split out the Linux-specific flags.
- Add MacOS plugin names to the gdextension file.